### PR TITLE
fix: detect writable SD card without GHL marker

### DIFF
--- a/extension/BhStorageHelper.java
+++ b/extension/BhStorageHelper.java
@@ -47,10 +47,10 @@ public final class BhStorageHelper {
     }
 
     /**
-     * Same algorithm GameHub uses: walk getExternalFilesDirs(), strip /Android/data,
-     * accept the mount whose root contains a writable GHL/ folder. Keeping the GHL
-     * convention preserves compatibility with users who already had Steam on SD via
-     * GameHub — they don't need to set up a different folder for BannerHub.
+     * Walk all app-specific external directories, skip primary shared storage, and
+     * derive the removable-volume root by stripping the /Android/data suffix.
+     * Accept the card when its bannerhub directory is writable, creating that
+     * directory when necessary so detection does not depend on a GHL marker.
      */
     private static String autoDetectSDCardRoot(Context ctx) {
         try {
@@ -62,8 +62,17 @@ public final class BhStorageHelper {
                 int idx = abs.indexOf("/Android/data");
                 if (idx < 0) continue;
                 String root = abs.substring(0, idx);
-                File ghl = new File(root, "GHL");
-                if (ghl.exists() && ghl.isDirectory() && ghl.canWrite()) {
+                File rootDir = new File(root);
+                File primaryDir = ctx.getExternalFilesDir(null);
+                if (!rootDir.exists() || !rootDir.isDirectory()) continue;
+                if (primaryDir != null
+                        && abs.equals(primaryDir.getAbsolutePath())) continue;
+
+                File bannerHubDir = new File(rootDir, "bannerhub");
+                if ((bannerHubDir.exists()
+                        && bannerHubDir.isDirectory()
+                        && bannerHubDir.canWrite())
+                        || (!bannerHubDir.exists() && bannerHubDir.mkdirs())) {
                     return root;
                 }
             }


### PR DESCRIPTION
## Summary

Fixes external-storage detection when a removable SD card does not already contain a writable `GHL` marker directory.

The detector now:

- enumerates app-specific external directories;
- skips primary shared storage;
- derives the removable-volume root from `/Android/data`;
- accepts an existing writable `bannerhub` directory; or
- creates `bannerhub` when it does not exist.

## Problem

On an LG V60, Android correctly mounted the SD card and BannerHub had `MANAGE_EXTERNAL_STORAGE`, but enabling **Save Store Games to External Storage (SD Card)** returned **No SD card found**.

The existing detector required `/storage/<volume>/GHL` to exist before it would accept the volume. Creating that directory manually made detection work, confirming the marker requirement as the failure.

## Testing

- Device: LG V60
- Removed/renamed the `GHL` marker before testing.
- Built the branch successfully using the repository’s quick APK workflow.
- Installed the generated APK as an isolated test package.
- Granted `MANAGE_EXTERNAL_STORAGE`.
- Enabled the external-storage toggle without an error.
- Verified `bh_storage_pref.xml` contained:
  - `bh_use_custom_storage=true`
  - `bh_storage_path=/storage/“sdcard id”`
- Restored the marker and removed the test package afterward.

This change affects BannerHub’s GOG/Epic/Amazon external-storage toggle only; it does not alter Steam storage behavior.